### PR TITLE
Access the document in the FileProcessor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/Crate.js
+++ b/lib/Crate.js
@@ -67,6 +67,7 @@ Crate.prototype.plugin = function(schema, options) {
       return callback(new Error('Attachment has no path property!'))
     }
 
+    var doc = this
     var model = this
 
     if(options.fields[field].array) {
@@ -116,13 +117,13 @@ Crate.prototype.plugin = function(schema, options) {
     // remove the old file if one already exists
     if(options.fields[field].processor.willOverwrite(model[field])) {
       tasks.push(function(callback) {
-        options.fields[field].processor.remove(options.storage, model[field], callback)
+        options.fields[field].processor.remove(options.storage, model[field], doc, callback)
       })
     }
 
     // process the attachment
     tasks.push(function(callback) {
-      options.fields[field].processor.process(attachment, options.storage, model[field], callback)
+      options.fields[field].processor.process(attachment, options.storage, model[field], doc, callback)
     })
 
     async.series(tasks, function(error) {
@@ -147,12 +148,12 @@ Crate.prototype.plugin = function(schema, options) {
       if(options.fields[field].array) {
         model[field].forEach(function(arrayField) {
           tasks.push(function(callback) {
-            options.fields[field].processor.remove(options.storage, arrayField, callback)
+            options.fields[field].processor.remove(options.storage, arrayField, model, callback)
           })
         })
       } else {
         tasks.push(function(callback) {
-          options.fields[field].processor.remove(options.storage, model[field], callback)
+          options.fields[field].processor.remove(options.storage, model[field], model, callback)
         })
       }
     })
@@ -210,14 +211,14 @@ Crate.prototype.plugin = function(schema, options) {
           if(!present) {
             // subDocument has been removed, delete the attachment
             tasks.push(function (callback) {
-              options.fields[field].processor.remove(options.storage, oldDoc, callback)
+              options.fields[field].processor.remove(options.storage, oldDoc, model, callback)
             })
           }
         })
       } else if(model.isModified(field)) {
         // if the attachment has been modified and there was an old one, remove the old version
         tasks.push(function (callback) {
-          options.fields[field].processor.remove(options.storage, model.__cached_attachments[field], callback)
+          options.fields[field].processor.remove(options.storage, model.__cached_attachments[field], model, callback)
         })
       }
     })

--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -15,7 +15,7 @@ FileProcessor.prototype.createFieldSchema = function() {
 }
 
 FileProcessor.prototype.process = function(attachment, storageProvider, model, doc, callback) {
-  storageProvider.save(attachment, function(error, url) {
+  storageProvider.save(attachment, doc, function(error, url) {
     model.size = attachment.size
     model.name = attachment.name
     model.type = attachment.type

--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -14,7 +14,7 @@ FileProcessor.prototype.createFieldSchema = function() {
   }
 }
 
-FileProcessor.prototype.process = function(attachment, storageProvider, model, callback) {
+FileProcessor.prototype.process = function(attachment, storageProvider, model, doc, callback) {
   storageProvider.save(attachment, function(error, url) {
     model.size = attachment.size
     model.name = attachment.name
@@ -29,7 +29,7 @@ FileProcessor.prototype.willOverwrite = function(model) {
   return !!model.url
 }
 
-FileProcessor.prototype.remove = function(storageProvider, model, callback) {
+FileProcessor.prototype.remove = function(storageProvider, model, doc, callback) {
   if(!model.url) {
     return callback()
   }

--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -34,7 +34,7 @@ FileProcessor.prototype.remove = function(storageProvider, model, doc, callback)
     return callback()
   }
 
-  storageProvider.remove(model, callback)
+  storageProvider.remove(model, doc, callback)
 }
 
 module.exports = FileProcessor

--- a/lib/StorageProvider.js
+++ b/lib/StorageProvider.js
@@ -3,7 +3,7 @@ var StorageProvider = function() {
 
 }
 
-StorageProvider.prototype.save = function(path, callback) {
+StorageProvider.prototype.save = function(attachment, callback) {
   throw new Error('StorageProvider#save not implemented')
 }
 

--- a/lib/StorageProvider.js
+++ b/lib/StorageProvider.js
@@ -7,7 +7,7 @@ StorageProvider.prototype.save = function(attachment, doc, callback) {
   throw new Error('StorageProvider#save not implemented')
 }
 
-StorageProvider.prototype.remove = function(attachment, callback) {
+StorageProvider.prototype.remove = function(attachment, doc, callback) {
   throw new Error('StorageProvider#remove not implemented')
 }
 

--- a/lib/StorageProvider.js
+++ b/lib/StorageProvider.js
@@ -3,7 +3,7 @@ var StorageProvider = function() {
 
 }
 
-StorageProvider.prototype.save = function(attachment, callback) {
+StorageProvider.prototype.save = function(attachment, doc, callback) {
   throw new Error('StorageProvider#save not implemented')
 }
 

--- a/test/CrateTest.js
+++ b/test/CrateTest.js
@@ -487,7 +487,7 @@ describe('Crate', function() {
       bar: {}
     })
     fileProcessor.process = function(attachment, storageProvider, model, doc, callback) {
-      storageProvider.save(attachment, function(error, url) {
+      storageProvider.save(attachment, doc, function(error, url) {
         ['foo', 'bar'].forEach(function(property) {
           model[property] = {
             size: attachment.size,

--- a/test/CrateTest.js
+++ b/test/CrateTest.js
@@ -486,7 +486,7 @@ describe('Crate', function() {
       foo: {},
       bar: {}
     })
-    fileProcessor.process = function(attachment, storageProvider, model, callback) {
+    fileProcessor.process = function(attachment, storageProvider, model, doc, callback) {
       storageProvider.save(attachment, function(error, url) {
         ['foo', 'bar'].forEach(function(property) {
           model[property] = {
@@ -501,7 +501,7 @@ describe('Crate', function() {
       })
     }
     fileProcessor.shouldRemove.returns(true)
-    fileProcessor.remove.callsArg(2)
+    fileProcessor.remove.callsArg(3)
 
     createSchemaWithFileProcessor(fileProcessor, function(StubSchema, storage) {
       var model = new StubSchema()

--- a/test/fixtures/StubFileProcessor.js
+++ b/test/fixtures/StubFileProcessor.js
@@ -33,7 +33,7 @@ StubFileProcessor.prototype.willOverwrite = function(model) {
 }
 
 StubFileProcessor.prototype.remove = function(storageProvider, model, doc, callback) {
-  storageProvider.remove(model, callback)
+  storageProvider.remove(model, doc, callback)
 }
 
 module.exports = StubFileProcessor

--- a/test/fixtures/StubFileProcessor.js
+++ b/test/fixtures/StubFileProcessor.js
@@ -18,7 +18,7 @@ StubFileProcessor.prototype.createFieldSchema = function() {
 }
 
 StubFileProcessor.prototype.process = function(attachment, storageProvider, model, doc, callback) {
-  storageProvider.save(attachment, function(error, url) {
+  storageProvider.save(attachment, doc, function(error, url) {
     model.size = attachment.size
     model.name = attachment.name
     model.type = attachment.type

--- a/test/fixtures/StubFileProcessor.js
+++ b/test/fixtures/StubFileProcessor.js
@@ -17,7 +17,7 @@ StubFileProcessor.prototype.createFieldSchema = function() {
   }
 }
 
-StubFileProcessor.prototype.process = function(attachment, storageProvider, model, callback) {
+StubFileProcessor.prototype.process = function(attachment, storageProvider, model, doc, callback) {
   storageProvider.save(attachment, function(error, url) {
     model.size = attachment.size
     model.name = attachment.name
@@ -32,7 +32,7 @@ StubFileProcessor.prototype.willOverwrite = function(model) {
   return !!model.url
 }
 
-StubFileProcessor.prototype.remove = function(storageProvider, model, callback) {
+StubFileProcessor.prototype.remove = function(storageProvider, model, doc, callback) {
   storageProvider.remove(model, callback)
 }
 

--- a/test/fixtures/StubSchema.js
+++ b/test/fixtures/StubSchema.js
@@ -11,7 +11,7 @@ module.exports = function(callback) {
 
   // happy path
   storage.save.callsArgWith(2, undefined, randomString(10))
-  storage.remove.callsArg(1)
+  storage.remove.callsArg(2)
 
   var StubSchema = new mongoose.Schema({
     name: {

--- a/test/fixtures/StubSchema.js
+++ b/test/fixtures/StubSchema.js
@@ -10,7 +10,7 @@ module.exports = function(callback) {
   }
 
   // happy path
-  storage.save.callsArgWith(1, undefined, randomString(10))
+  storage.save.callsArgWith(2, undefined, randomString(10))
   storage.remove.callsArg(1)
 
   var StubSchema = new mongoose.Schema({

--- a/test/fixtures/StubSchemaWithArrayProperty.js
+++ b/test/fixtures/StubSchemaWithArrayProperty.js
@@ -11,7 +11,7 @@ module.exports = function(callback) {
 
   // happy path
   storage.save.callsArgWith(2, undefined, randomString(10))
-  storage.remove.callsArg(1)
+  storage.remove.callsArg(2)
 
   var StubSchema = new mongoose.Schema({
     name: {

--- a/test/fixtures/StubSchemaWithArrayProperty.js
+++ b/test/fixtures/StubSchemaWithArrayProperty.js
@@ -10,7 +10,7 @@ module.exports = function(callback) {
   }
 
   // happy path
-  storage.save.callsArgWith(1, undefined, randomString(10))
+  storage.save.callsArgWith(2, undefined, randomString(10))
   storage.remove.callsArg(1)
 
   var StubSchema = new mongoose.Schema({

--- a/test/fixtures/StubSchemaWithFileProcessor.js
+++ b/test/fixtures/StubSchemaWithFileProcessor.js
@@ -10,7 +10,7 @@ module.exports = function(processor, callback) {
   }
 
   // happy path
-  storage.save.callsArgWith(1, undefined, randomString(10))
+  storage.save.callsArgWith(2, undefined, randomString(10))
   storage.remove.callsArg(1)
 
   var StubSchema = new mongoose.Schema({

--- a/test/fixtures/StubSchemaWithFileProcessor.js
+++ b/test/fixtures/StubSchemaWithFileProcessor.js
@@ -11,7 +11,7 @@ module.exports = function(processor, callback) {
 
   // happy path
   storage.save.callsArgWith(2, undefined, randomString(10))
-  storage.remove.callsArg(1)
+  storage.remove.callsArg(2)
 
   var StubSchema = new mongoose.Schema({
     name: {

--- a/test/fixtures/StubSchemaWithUnselectedName.js
+++ b/test/fixtures/StubSchemaWithUnselectedName.js
@@ -11,7 +11,7 @@ module.exports = function(callback) {
 
   // happy path
   storage.save.callsArgWith(2, undefined, randomString(10))
-  storage.remove.callsArg(1)
+  storage.remove.callsArg(2)
 
   var StubSchema = new mongoose.Schema({
     name: {

--- a/test/fixtures/StubSchemaWithUnselectedName.js
+++ b/test/fixtures/StubSchemaWithUnselectedName.js
@@ -10,7 +10,7 @@ module.exports = function(callback) {
   }
 
   // happy path
-  storage.save.callsArgWith(1, undefined, randomString(10))
+  storage.save.callsArgWith(2, undefined, randomString(10))
   storage.remove.callsArg(1)
 
   var StubSchema = new mongoose.Schema({

--- a/test/fixtures/StubStorageProvider.js
+++ b/test/fixtures/StubStorageProvider.js
@@ -6,8 +6,8 @@ var StubStorageProvider = function() {
 }
 util.inherits(StubStorageProvider, StorageProvider)
 
-StubStorageProvider.prototype.save = function(path, callback) {
-  callback(null, path)
+StubStorageProvider.prototype.save = function(attachment, callback) {
+  callback(null, attachment)
 }
 
 StubStorageProvider.prototype.remove = function(attachment, callback) {

--- a/test/fixtures/StubStorageProvider.js
+++ b/test/fixtures/StubStorageProvider.js
@@ -6,7 +6,7 @@ var StubStorageProvider = function() {
 }
 util.inherits(StubStorageProvider, StorageProvider)
 
-StubStorageProvider.prototype.save = function(attachment, callback) {
+StubStorageProvider.prototype.save = function(attachment, doc, callback) {
   callback(null, attachment)
 }
 

--- a/test/fixtures/StubStorageProvider.js
+++ b/test/fixtures/StubStorageProvider.js
@@ -10,7 +10,7 @@ StubStorageProvider.prototype.save = function(attachment, doc, callback) {
   callback(null, attachment)
 }
 
-StubStorageProvider.prototype.remove = function(attachment, callback) {
+StubStorageProvider.prototype.remove = function(attachment, doc, callback) {
   callback()
 }
 


### PR DESCRIPTION
I added the mongoose document to the method call of "save" and "remove" of the FileProcessor, so you can access it and pass it to the StorageProvider.

This is a breaking change for all projects who create an own FileProcessor.

Next step is the modification of the [mongoose-crate-localfs](https://github.com/achingbrain/mongoose-crate). I want to pass the the document to the `path` function.

In addition I want to add the ability to use a function for the option `directory`. 

Both functions (document and path) should get a optional callback function passed, to support async behavior.

Sorry for my bad english :stuck_out_tongue_closed_eyes:
