### PR TITLE
Implementing support for nested properties

### DIFF
--- a/lib/Crate.js
+++ b/lib/Crate.js
@@ -8,6 +8,7 @@ const mmm = require('mmmagic')
 const Magic = mmm.Magic
 const check = require('check-types')
 const FileProcessor = require('./FileProcessor')
+const _ = require('lodash')
 
 class Crate {
   constructor () {
@@ -86,9 +87,10 @@ class Crate {
       let modelArray
 
       if (options.fields[field].array) {
-        modelArray = this[field]
+        modelArray = _.get(this, field)
         model = {}
-        model[field] = this[field].create()
+        const created = _.get(this, field).create()
+        _.set(model, field, created)
       }
 
       // the things we will do to the file
@@ -130,15 +132,15 @@ class Crate {
       }
 
       // remove the old file if one already exists
-      if (options.fields[field].processor.willOverwrite(model[field])) {
+      if (options.fields[field].processor.willOverwrite(_.get(model, field))) {
         tasks.push(next => {
-          options.fields[field].processor.remove(options.storage, model[field], next)
+          options.fields[field].processor.remove(options.storage, _.get(model, field), next)
         })
       }
 
       // process the attachment
       tasks.push(next => {
-        options.fields[field].processor.process(attachment, options.storage, model[field], next)
+        options.fields[field].processor.process(attachment, options.storage, _.get(model, field), next)
       })
 
       const attach = next => {
@@ -148,7 +150,7 @@ class Crate {
           }
 
           if (options.fields[field].array) {
-            modelArray.push(model[field])
+            modelArray.push(_.get(model, field))
           }
 
           next()
@@ -177,14 +179,14 @@ class Crate {
 
       Object.keys(options.fields).forEach((field) => {
         if (options.fields[field].array) {
-          model[field].forEach((arrayField) => {
+          _.get(model, field).forEach((arrayField) => {
             tasks.push((callback) => {
               options.fields[field].processor.remove(options.storage, arrayField, callback)
             })
           })
         } else {
           tasks.push((callback) => {
-            options.fields[field].processor.remove(options.storage, model[field], callback)
+            options.fields[field].processor.remove(options.storage, _.get(model, field), callback)
           })
         }
       })
@@ -208,8 +210,8 @@ class Crate {
       doc.__cached_attachments = {}
 
       Object.keys(options.fields).forEach((field) => {
-        if (model[field]) {
-          doc.__cached_attachments[field] = JSON.parse(JSON.stringify(model[field]))
+        if (_.get(model, field)) {
+          doc.__cached_attachments[field] = JSON.parse(JSON.stringify(_.get(model, field)))
         }
       })
     })
@@ -233,7 +235,7 @@ class Crate {
           model.__cached_attachments[field].forEach((oldDoc) => {
             let present = false
 
-            model[field].forEach((currentDoc) => {
+            _.get(model, field).forEach((currentDoc) => {
               if (currentDoc._id.equals(oldDoc._id)) {
                 present = true
               }

--- a/lib/FileProcessor.js
+++ b/lib/FileProcessor.js
@@ -25,7 +25,7 @@ class FileProcessor {
   }
 
   willOverwrite (model) {
-    return !!model.url
+    return !!model && !!model.url
   }
 
   remove (storageProvider, model, callback) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "check-types": "^7.0.0",
+    "lodash": "^4.17.4",
     "mmmagic": "^0.4.4"
   },
   "devDependencies": {

--- a/test/CrateTest.js
+++ b/test/CrateTest.js
@@ -9,6 +9,8 @@ const mockgoose = require('mockgoose')
 const async = require('async')
 const Crate = require('../lib/Crate')
 const createSchema = require('./fixtures/StubSchema')
+const createNestedSchema = require('./fixtures/StubNestedSchema')
+const createNestedSchemaWithArrayProperty = require('./fixtures/StubNestedSchemaWithArrayProperty')
 const createSchemaWithArrayProperty = require('./fixtures/StubSchemaWithArrayProperty')
 const createSchemaWithFileProcessor = require('./fixtures/StubSchemaWithFileProcessor')
 const createSchemaWithUnselectedName = require('./fixtures/StubSchemaWithUnselectedName')
@@ -40,6 +42,28 @@ describe('Crate', () => {
 
         // this can vary depending on file system...
         model.file.size.should.be.greaterThan(17000)
+
+        done()
+      })
+    })
+  })
+
+  it('should attach a file in nested property', (done) => {
+    const file = path.resolve(path.join(__dirname, '.', 'fixtures', 'node_js_logo.png'))
+
+    createNestedSchema((StubSchema) => {
+      var model = new StubSchema()
+      model.attach('nested.file', {
+        path: file
+      }, (error) => {
+        should(error).not.ok
+
+        model.nested.file.type.should.equal('image/png')
+        model.nested.file.name.should.equal('node_js_logo.png')
+        model.nested.file.url.should.be.ok
+
+        // this can vary depending on file system...
+        model.nested.file.size.should.be.greaterThan(17000)
 
         done()
       })
@@ -88,6 +112,25 @@ describe('Crate', () => {
     })
   })
 
+  it('should attach a file to an array in nested property', (done) => {
+    const file = path.resolve(path.join(__dirname, '.', 'fixtures', 'node_js_logo.png'))
+
+    createNestedSchemaWithArrayProperty((StubSchema) => {
+      var model = new StubSchema()
+
+      model.nested.files.length.should.equal(0)
+      model.attach('nested.files', {
+        path: file
+      }, function (error) {
+        should(error).not.ok
+
+        model.nested.files.length.should.equal(1)
+
+        done()
+      })
+    })
+  })
+
   it('should error on non attachment field', (done) => {
     const file = path.resolve(path.join(__dirname, '.', 'fixtures', 'node_js_logo.png'))
 
@@ -111,11 +154,11 @@ describe('Crate', () => {
       model.attach('foo', {
         path: file
       })
-      .catch(error => {
-        error.should.be.ok
+        .catch(error => {
+          error.should.be.ok
 
-        done()
-      })
+          done()
+        })
     })
   })
 
@@ -134,11 +177,11 @@ describe('Crate', () => {
     createSchema((StubSchema) => {
       var model = new StubSchema()
       model.attach('file', {})
-      .catch(error => {
-        error.should.be.ok
+        .catch(error => {
+          error.should.be.ok
 
-        done()
-      })
+          done()
+        })
     })
   })
 
@@ -165,11 +208,11 @@ describe('Crate', () => {
       model.attach('file', {
         path: file
       })
-      .catch(error => {
-        error.should.be.ok
+        .catch(error => {
+          error.should.be.ok
 
-        done()
-      })
+          done()
+        })
     })
   })
 
@@ -273,15 +316,16 @@ describe('Crate', () => {
         model.attach('files', {
           path: file
         })
-        .then(() => {
-          storage.remove.callCount.should.equal(0)
+          .then(() => {
+            storage.remove.callCount.should.equal(0)
 
-          return model.remove()
-        }).then(() => {
-          storage.remove.callCount.should.equal(2)
+            return model.remove()
+          }).then(
+          () => {
+            storage.remove.callCount.should.equal(2)
 
-          done()
-        })
+            done()
+          })
       })
     })
   })

--- a/test/fixtures/StubNestedSchema.js
+++ b/test/fixtures/StubNestedSchema.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const mongoose = require('mongoose')
+const crate = require('../../index')
+const sinon = require('sinon')
+const randomString = require('./randomString')
+
+module.exports = (callback) => {
+  const storage = {
+    save: sinon.stub(),
+    remove: sinon.stub()
+  }
+
+  // happy path
+  storage.save.callsArgWith(1, undefined, randomString(10))
+  storage.remove.callsArg(1)
+
+  const StubSchema = new mongoose.Schema({
+    name: {
+      type: String,
+      required: true
+    }
+  })
+
+  StubSchema.plugin(crate, {
+    storage: storage,
+    fields: {
+      'nested.file': {}
+    }
+  })
+
+  const model = mongoose.model(randomString(10), StubSchema)
+
+  callback(model, storage)
+}

--- a/test/fixtures/StubNestedSchemaWithArrayProperty.js
+++ b/test/fixtures/StubNestedSchemaWithArrayProperty.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const mongoose = require('mongoose')
+const crate = require('../../index')
+const sinon = require('sinon')
+const randomString = require('./randomString')
+
+module.exports = (callback) => {
+  const storage = {
+    save: sinon.stub(),
+    remove: sinon.stub()
+  }
+
+  // happy path
+  storage.save.callsArgWith(1, undefined, randomString(10))
+  storage.remove.callsArg(1)
+
+  const StubSchema = new mongoose.Schema({
+    name: {
+      type: String,
+      required: true
+    }
+  })
+
+  StubSchema.plugin(crate, {
+    storage: storage,
+    fields: {
+      'nested.files': {
+        array: true
+      }
+    }
+  })
+
+  const model = mongoose.model(randomString(10), StubSchema)
+
+  callback(model, storage)
+}


### PR DESCRIPTION
I've added support for declaring and attaching files in nested properties.

Defining nested fields:

```js
schema.plugin(crate, {
    storage: storage,
    fields: {
       'nested.attachments': {}
    }
});
```

Attaching to nested field:

```js
model.attach('nested.attachment', {path: '/path/to/file'})
```

I've added the dependency for [lodash](https://github.com/lodash/lodash) to manage `get` and `set` nested fields from string, I try to make it work with [mpath](https://github.com/aheckmann/mpath) that is the native from mongoose but the `set` method was not working as expected, it was not setting the nested property. 