### PR TITLE
Support for streams and buffers #8

### DIFF
--- a/lib/Crate.js
+++ b/lib/Crate.js
@@ -72,8 +72,8 @@ class Crate {
         return Promise.reject(error)
       }
 
-      if (!attachment || !attachment.path) {
-        const error = new Error('Attachment has no path property!')
+      if (!attachment || (!attachment.path && !attachment.buffer && !attachment.stream)) {
+        const error = new Error('Attachment has no path|buffer|stream property!')
 
         if (callback) {
           return callback(error)
@@ -95,14 +95,16 @@ class Crate {
       const tasks = []
 
       // make sure the file actually exists
-      tasks.push(next => {
-        fs.exists(attachment.path, function (result) {
-          next(!result ? new Error('No file exists at ' + attachment.path) : undefined)
+      if (attachment.path) {
+        tasks.push(next => {
+          fs.exists(attachment.path, function (result) {
+            next(!result ? new Error('No file exists at ' + attachment.path) : undefined)
+          })
         })
-      })
+      }
 
       // make sure there's a mimetype
-      if (!attachment.type) {
+      if (!attachment.type && attachment.path) {
         tasks.push(next => {
           self._magic.detectFile(attachment.path, (error, type) => {
             attachment.type = type
@@ -112,7 +114,7 @@ class Crate {
       }
 
       // make sure there's an original name
-      if (!attachment.name) {
+      if (!attachment.name && attachment.path) {
         tasks.push(next => {
           attachment.name = path.basename(attachment.path)
           next()
@@ -121,12 +123,19 @@ class Crate {
 
       // get the filesize
       if (!attachment.size) {
-        tasks.push(next => {
-          fs.stat(attachment.path, (error, stats) => {
-            attachment.size = stats.size
-            next(error)
+        if (attachment.path) {
+          tasks.push(next => {
+            fs.stat(attachment.path, (error, stats) => {
+              attachment.size = stats.size
+              next(error)
+            })
           })
-        })
+        } else if (attachment.buffer) {
+          tasks.push(next => {
+            attachment.size = attachment.buffer.length
+            next()
+          })
+        }
       }
 
       // remove the old file if one already exists


### PR DESCRIPTION
This is a proposition for supporting streams and buffers. 

It doesn't break compatibility with current StorageProvider implmentations, but they must handle "attachment.buffer" and "attachment.stream" in addition to "attachment.path" in order for streams and buffers to work.

It is not hard to implement this in the StorageProviders (piping a stream to a local file is supported, knox supports streams, etc)
Another idea is to just refactor and handle everything as a stream (wrapping buffer and path into stream, and pass that to StorageProviders)